### PR TITLE
Change ModuleKind to CommonJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function(sails) {
         return cb();
       }
    
-      var compilerOptions = { module: ts.ModuleKind.System };
+      var compilerOptions = { module: ts.ModuleKind.CommonJS };
       
       self.checkIgnored = function(dir) {
         


### PR DESCRIPTION
Changing the ModuleKind to CommonJS solved some problems  to me. Now I can, for example, transpile this code:

    async function slow() {
        return new Promise(function(resolve, reject) {
            setTimeout(function() {
                console.log("slow finished");
                resolve();
            }, 3000);
        });
    }

    function fast() {
        console.log("fast");
    }

    async function run() {
        await slow();
        fast();
    }

    run();